### PR TITLE
fix: repo being displayed in table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,70 +3,64 @@
 </h1>
 <p align="center">List of Open Source projects by Mozambican Developers</p>
 
-
-
 <p align="center">
   <a href="#A">A</a> | <a href="#B">B</a> | <a href="#C">C</a> | <a href="#D">D</a> | <a href="#E">E</a> | <a href="#F">F</a> | <a href="#G">G</a> | <a href="#H">H</a> | <a href="#I">I</a> | <a href="#J">J</a> | <a href="#K">K</a> | <a href="#L">L</a> | <a href="#M">M</a> | <a href="#N">N</a> | <a href="#O">O</a> | <a href="#P">P</a> | <a href="#Q">Q</a> | <a href="#R">R</a> | <a href="#S">S</a> | <a href="#T">T</a> | <a href="#U">U</a> | <a href="#V">V</a> | <a href="#W">W</a> | <a href="#X">X</a> | <a href="#Y">Y</a> | <a href="#Z">Z</a>
 </p>
 
-
 ## <a name="C"> </a>C
 
-* [cambiomz](https://github.com/kradnoel/cambiomz) - Unofficial BCI Exchange API, that let you get the money exchange data available on Mozambique BCI Bank website. **By [@kradnoel](https://github.com/kradnoel)**
+- [cambiomz](https://github.com/kradnoel/cambiomz) - Unofficial BCI Exchange API, that let you get the money exchange data available on Mozambique BCI Bank website. **By [@kradnoel](https://github.com/kradnoel)**
 
-* [Colpal](https://github.com/themisterpaps/colpal) - 🎨 Color recommendation, color palettes, Flat UI colors, Modern Gradients and Monochromatic Palettes website, built with basicly html and css and 5 lines of javascript. **By [@themisterpaps](https://github.com/themisterpaps/)**
-
+- [Colpal](https://github.com/themisterpaps/colpal) - 🎨 Color recommendation, color palettes, Flat UI colors, Modern Gradients and Monochromatic Palettes website, built with basicly html and css and 5 lines of javascript. **By [@themisterpaps](https://github.com/themisterpaps/)**
 
 ## <a name="D"> </a>D
 
-* [Data4School](https://github.com/HercoZauZau/Data4School) - Mozambican Schools Data Analysis. **By [@hercozauzau](https://github.com/hercozauzau)**
-
+- [Data4School](https://github.com/HercoZauZau/Data4School) - Mozambican Schools Data Analysis. **By [@hercozauzau](https://github.com/hercozauzau)**
 
 ## <a name="F"> </a>F
 
-* [firecoil](https://github.com/thatfiredev/firecoil) - Load images from Cloud Storage for Firebase in your Android app (through a StorageReference), using the image loading library Coil. **By [@thatfiredev](https://github.com/thatfiredev)**
-
+- [firecoil](https://github.com/thatfiredev/firecoil) - Load images from Cloud Storage for Firebase in your Android app (through a StorageReference), using the image loading library Coil. **By [@thatfiredev](https://github.com/thatfiredev)**
 
 ## <a name="G"> </a>G
 
-* [GitHub_Insights--Mozambique](https://github.com/HercoZauZau/GitHub_Insights--Mozambique) - Exploring the Mozambican developer ecosystem through github data analysis. **By [@hercozauzau](https://github.com/hercozauzau)**
-
+- [GitHub_Insights--Mozambique](https://github.com/HercoZauZau/GitHub_Insights--Mozambique) - Exploring the Mozambican developer ecosystem through github data analysis. **By [@hercozauzau](https://github.com/hercozauzau)**
 
 ## <a name="M"> </a>M
 
-* [mpesasdk](https://github.com/realdm/mpesasdk) - unofficial SDK with the aim to make it easy to integrate with the Vodacom Mozambique M-Pesa payments API on android apps. **By [@realdm](https://github.com/realdm)**
+- [mpesasdk](https://github.com/realdm/mpesasdk) - unofficial SDK with the aim to make it easy to integrate with the Vodacom Mozambique M-Pesa payments API on android apps. **By [@realdm](https://github.com/realdm)**
 
-* [mpesa-node-api](https://github.com/thatfiredev/mpesa-node-api) - Node.js wrapper for M-Pesa API (Mozambique). **By [@thatfiredev](https://github.com/thatfiredev)**
+- [mpesa-node-api](https://github.com/thatfiredev/mpesa-node-api) - Node.js wrapper for M-Pesa API (Mozambique). **By [@thatfiredev](https://github.com/thatfiredev)**
 
-* [mpesa-php-api](https://github.com/abdulmueid/mpesa-php-api) - PHP library for M-Pesa API (Mozambique). **By [@abdulmueid](https://github.com/abdulmueid)**
+- [mpesa-php-api](https://github.com/abdulmueid/mpesa-php-api) - PHP library for M-Pesa API (Mozambique). **By [@abdulmueid](https://github.com/abdulmueid)**
 
-* [mpesa_sdk_dart](https://github.com/realrgt/mpesa_sdk_dart) - Dart | Flutter library for M-Pesa API (Mozambique). **By [@realrgt](https://github.com/realrgt)**
+- [mpesa_sdk_dart](https://github.com/realrgt/mpesa_sdk_dart) - Dart \| Flutter library for M-Pesa API (Mozambique). **By [@realrgt](https://github.com/realrgt)**
 
-* [mpesa-wordpress-plugin](https://github.com/herquiloidehele/mpesa-wordpress-plugin) - M-PESA Payment Gateway for woocommerce - Wordpress. **By [@herquiloidehele](https://github.com/herquiloidehele)**
-* [Mozambique Developer Survey](https://github.com/mozdevz/Mozambique-Developer-Survey) - Mozambique Developer Survey is a comprehensive survey organized by [@mozdevz](https://github.com/mozdevz) to uncover the world of developers in Mozambique. 
+- [mpesa-wordpress-plugin](https://github.com/herquiloidehele/mpesa-wordpress-plugin) - M-PESA Payment Gateway for woocommerce - Wordpress. **By [@herquiloidehele](https://github.com/herquiloidehele)**
 
+- [Mozambique Developer Survey](https://github.com/mozdevz/Mozambique-Developer-Survey) - Mozambique Developer Survey is a comprehensive survey organized by [@mozdevz](https://github.com/mozdevz) to uncover the world of developers in Mozambique.
 
 ## <a name="N"> </a>N
 
-* [Nyandayeyo](https://github.com/Nelzio/Nyandayeyo) - Reports App **By [@Nelzio](https://github.com/Nelzio)**
+- [Nyandayeyo](https://github.com/Nelzio/Nyandayeyo) - Reports App **By [@Nelzio](https://github.com/Nelzio)**
 
 ## <a name="P"> </a>P
 
-* [PaymentsDS](https://github.com/paymentsds) (Payments Developer Suite) - a suite of SDKs aiming to help businesses integrating M-Pesa operations into their  applications.
+- [PaymentsDS](https://github.com/paymentsds) (Payments Developer Suite) - a suite of SDKs aiming to help businesses integrating M-Pesa operations into their applications.
 
 ## <a name="R"> </a>R
 
-* [reaque](https://github.com/horaciocome1/reaque) - Repository for the Reaque android app. Reaque is a mobile tool where you can share and find stories from Mozambique. From thoughts and culture, through history and gastronomy, to tourism and even fashion, if it is something about Mozambique, you should share or find it in Reaque.
- **By [@horaciocome1](https://github.com/horaciocome1)**
+- [reaque](https://github.com/horaciocome1/reaque) - Repository for the Reaque android app. Reaque is a mobile tool where you can share and find stories from Mozambique. From thoughts and culture, through history and gastronomy, to tourism and even fashion, if it is something about Mozambique, you should share or find it in Reaque.
+  **By [@horaciocome1](https://github.com/horaciocome1)**
 
 ## <a name="S"> </a>S
 
-* [simple-recyclerview-adapter](https://github.com/horaciocome1/simple-recyclerview-adapter) - General purpose object that can be costumized to each case (item layout) by the time of creation. Similar to what is done on Listview with default adapters. Compatible with androidx.
- **By [@horaciocome1](https://github.com/horaciocome1)**
+- [simple-recyclerview-adapter](https://github.com/horaciocome1/simple-recyclerview-adapter) - General purpose object that can be costumized to each case (item layout) by the time of creation. Similar to what is done on Listview with default adapters. Compatible with androidx.
+  **By [@horaciocome1](https://github.com/horaciocome1)**
 
-* [simple-recyclerview-touch-listener](https://github.com/horaciocome1/simple-recyclerview-touch-listener) - An android library to simple handle user touch events over recyclerview.
- **By [@horaciocome1](https://github.com/horaciocome1)**
+- [simple-recyclerview-touch-listener](https://github.com/horaciocome1/simple-recyclerview-touch-listener) - An android library to simple handle user touch events over recyclerview.
+  **By [@horaciocome1](https://github.com/horaciocome1)**
 
 ## <a name="T"> </a>T
-* [Tocha](https://github.com/thatfiredev/Tocha) - 🔥 Full-Text Search for Firebase Projects that use the Spark (Free) plan.
- **By [@thatfiredev](https://github.com/thatfiredev)**
+
+- [Tocha](https://github.com/thatfiredev/Tocha) - 🔥 Full-Text Search for Firebase Projects that use the Spark (Free) plan.
+  **By [@thatfiredev](https://github.com/thatfiredev)**


### PR DESCRIPTION
Closes #12 

## Description 

This PR fixes the issue @thatfiredev reported in 2020, expecting that all the repos should have the same look (no tables)

## Screenshots

**Before:** 

![image](https://github.com/mozdevz/opensource/assets/56705157/9174eec1-60f5-461a-b3c4-068510764b63)

**Now:**

![image](https://github.com/mozdevz/opensource/assets/56705157/66dd73a8-12cc-45ae-a37b-6bfa010744ca)

**PS:** I activated gh pages on my repo you can take a look to see this PR version deploy [here](https://eusebiosimango.github.io/opensource-mz/)
